### PR TITLE
PassThroughPattern: ^(.*\.fedoraproject\.org):443$

### DIFF
--- a/apt-cacher-ng
+++ b/apt-cacher-ng
@@ -37,6 +37,8 @@ If requests fail because the file type is not allowed, create a pattern for
 volatile data:
 VfilePatternEx: .*metalink?repo=fedora*
 
+To allow for the initial download of the mirror sites in a fresh fedora template add:
+PassThroughPattern: ^(.*\.fedoraproject\.org):443$
 
 3.  TLS SUPPORT:
 Two methods:


### PR DESCRIPTION
Hi unman,
I recently had the need to also update a fedora template (base for qubes-builder) through apt-cacher-ng. I had to ass this PassThroughPattern to make the initial 'dnf update' work. I don't think this is needed for subsequent updates. In any case it might be nice to add to your notes. I am also guessing about the "download of the mirror sites" part ... so please check before accepting. Cheers, /Sven