### PR TITLE
updated the APT-cacher-ng.md for adding dom0 update proxy section under the "Install" section

### DIFF
--- a/apt-cacher-ng.md
+++ b/apt-cacher-ng.md
@@ -19,6 +19,16 @@ systemctl mask apt-cacher-ng
 ```
 Shut down template-cacher.
 
+#### If want to be the DOM0 update proxy
+Open the template-cacher terminal - 
+`qvm-run template-cacher terminal`
+
+In template-cacher install the qubes-dom0-update package, running as root:
+```
+apt-get install qubes-core-agent-dom0-updates
+```
+Shutdown template-cacher.
+
 ### Create and configure the proxy
 
 Create a qube and give it plenty of space on the private volume:


### PR DESCRIPTION

Added the "If want to be DOM0 update proxy" for anyone want the cacher to be the dom0 update proxy.