### PR TITLE
Fix link in tasks.html

### DIFF
--- a/qubes.3isec.org/tasks.html
+++ b/qubes.3isec.org/tasks.html
@@ -20,7 +20,7 @@ Instead of a user finding a guide online, wondering whether to create a new temp
 <p>
 Here's an example:
 <br>
-Let's say a user wants to set up a caching proxy, perhaps following my notes <a href="https://github.com/unman/notes/blob/master/apt-cacher-ng">here</a>
+Let's say a user wants to set up a caching proxy, perhaps following my notes <a href="https://github.com/unman/notes/blob/master/apt-cacher-ng.md">here</a>
 <br>
 They clone a template, install software in to the template, (remembering to mask the service in the template), create a qube, configure the qube, configure bind-dirs in the new qube, set up a new policy in dom0, and then change the repo definitions in all the templates so that the proxy can handle TLS requests.
 <br>


### PR DESCRIPTION
Corrected link from https://github.com/unman/notes/blob/master/apt-cacher-ng to https://github.com/unman/notes/blob/master/apt-cacher-ng.md.