### PR TITLE
Notes - disposable qubes - send 'root' volume writes to tmpfs

### DIFF
--- a/Really_Disposable_Qubes.md
+++ b/Really_Disposable_Qubes.md
@@ -12,6 +12,7 @@ mkdir /home/user/tmp
 sudo mount -t tmpfs -o size=2G new /home/user/tmp/
 qvm-pool add -o revisions_to_keep=1 -o dir_path=/home/user/tmp/ newer file 
 qvm-create new -P newer -t debian-11  -l purple --property netvm=tor
+qvm-volume set new:root rw False
 qvm-run new firefox-esr
 ```
 


### PR DESCRIPTION
Make new:root read-only, redirecting 'root' volume writes to the 'volatile' volume (which is in the 'newer' tmpfs pool, whereas the 'root' volume snapshot is in the pool of debian-11).

See discussion in QubesOS/qubes-issues#8704